### PR TITLE
fix: proper types definition + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ import { faFlag } from '@fortawesome/free-solid-svg-icons'
 * `flip`: `string` values `horizontal`, `vertical`, `both`
 * `pull`: `string` values `left`, `right`
 * `rotate`: `number or string` values `90`, `180`, `270`, `30`, `-30` ...
-* `size`: `string` values `xs`, `sm`, `lg` or `2x`, `3x`, `4x` ...
+* `size`: `string` values `xs`, `sm`, `lg` or `2x`, `3x`, `4x`, ..., `10x`
 * `color`: icon color, default `currentColor`
 
 ## Duotone Icons

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dev:build": "cd docs && rollup -c -w",
     "dev:serve": "sirv docs --dev",
     "dev": "run-p dev:build dev:serve",
-    "test": "jest test --coverage"
+    "test": "tsd && jest test --coverage"
   },
   "devDependencies": {
     "@babel/core": "^7.4.4",
@@ -57,6 +57,15 @@
     "rollup": "^2.2.0",
     "rollup-plugin-svelte": "^6.1.1",
     "sirv-cli": "^1.0.0",
-    "svelte": "^3.16.5"
+    "svelte": "^3.16.5",
+    "tsd": "^0.13.1"
+  },
+  "tsd": {
+    "directory": "test",
+    "compilerOptions": {
+      "lib": [
+        "dom"
+      ]
+    }
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,5 @@
-import { SvelteComponent } from "svelte"
+import { IconDefinition } from '@fortawesome/fontawesome-common-types'
+import { SvelteComponent } from 'svelte'
 
 declare class Fa extends SvelteComponent {
   constructor(options: any)
@@ -8,12 +9,25 @@ declare class Fa extends SvelteComponent {
     id?: string
     style?: string
 
-    icon: { icon: any }
+    icon: IconDefinition
     fw?: boolean
-    flip?: string
-    pull?: string
+    flip?: 'horizontal' | 'vertical' | 'both'
+    pull?: 'left' | 'right'
     rotate?: number | string
-    size?: string
+    size?:
+      | 'xs'
+      | 'sm'
+      | 'lg'
+      | '1x'
+      | '2x'
+      | '3x'
+      | '4x'
+      | '5x'
+      | '6x'
+      | '7x'
+      | '8x'
+      | '9x'
+      | '10x'
     color?: string
 
     // Duotone Icons

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,0 +1,45 @@
+import { IconDefinition } from '@fortawesome/fontawesome-common-types'
+import { SvelteComponent } from 'svelte'
+import { expectAssignable, expectNotType, expectType } from 'tsd'
+import Fa from '../src/index'
+
+const fa = new Fa({})
+
+expectAssignable<SvelteComponent>(fa)
+
+expectNotType<undefined>(fa.$$prop_def.icon)
+expectNotType<string>(fa.$$prop_def.flip)
+expectNotType<string>(fa.$$prop_def.pull)
+expectNotType<string>(fa.$$prop_def.size)
+
+expectType<string | undefined>(fa.$$prop_def.class)
+expectType<string | undefined>(fa.$$prop_def.id)
+expectType<string | undefined>(fa.$$prop_def.style)
+expectType<IconDefinition>(fa.$$prop_def.icon)
+expectType<'both' | 'horizontal' | 'vertical' | undefined>(fa.$$prop_def.flip)
+expectType<'left' | 'right' | undefined>(fa.$$prop_def.pull)
+expectType<string | number | undefined>(fa.$$prop_def.rotate)
+expectType<
+  | 'xs'
+  | 'sm'
+  | 'lg'
+  | '1x'
+  | '2x'
+  | '3x'
+  | '4x'
+  | '5x'
+  | '6x'
+  | '7x'
+  | '8x'
+  | '9x'
+  | '10x'
+  | undefined
+>(fa.$$prop_def.size)
+expectType<boolean | undefined>(fa.$$prop_def.fw)
+expectType<string | undefined>(fa.$$prop_def.color)
+expectType<string | undefined>(fa.$$prop_def.primaryColor)
+expectType<string | number | undefined>(fa.$$prop_def.primaryOpacity)
+expectType<string | undefined>(fa.$$prop_def.secondaryColor)
+expectType<string | number | undefined>(fa.$$prop_def.secondaryOpacity)
+expectType<boolean | undefined>(fa.$$prop_def.swapOpacity)
+


### PR DESCRIPTION
This PR brings proper type definitions based on FA5 for the icons.

It also adds tests for those types. Tests use [tsd](https://github.com/SamVerschueren/tsd) which I made it run before normal tests:

```sh
# package.json
"test": "tsd && jest test --coverage"
```

NOTE: 

the properties `size`, `flip` and `pull` have been forced to accept `types` that are similar to the FA CSS classes.

While this does not change much for `flip` and `pull`, it means that `size` cannot accept arbitrary strings in the form `#x`. Now the number part (`#`) goes from `2` to `10` only. Have a look in the file `src/index.d.ts`