### PR TITLE
Allow fractional sizes

### DIFF
--- a/src/fa.d.ts
+++ b/src/fa.d.ts
@@ -12,20 +12,21 @@ declare class Fa extends SvelteComponent {
     icon: IconDefinition
 
     size?:
-      | 'xs'
-      | 'sm'
-      | 'lg'
-      | '1x'
-      | '2x'
-      | '3x'
-      | '4x'
-      | '5x'
-      | '6x'
-      | '7x'
-      | '8x'
-      | '9x'
-      | '10x'
-    color?: string
+      | "lg"
+      | "xs"
+      | "sm"
+      | "1x"
+      | "2x"
+      | "3x"
+      | "4x"
+      | "5x"
+      | "6x"
+      | "7x"
+      | "8x"
+      | "9x"
+      | "10x"
+      | (`${number}x` & {});
+    color?: string;
 
     fw?: boolean
     pull?: 'left' | 'right'

--- a/src/fa.d.ts
+++ b/src/fa.d.ts
@@ -12,9 +12,9 @@ declare class Fa extends SvelteComponent {
     icon: IconDefinition
 
     size?:
-      | 'lg'
       | 'xs'
       | 'sm'
+      | 'lg'
       | '1x'
       | '2x'
       | '3x'

--- a/src/fa.d.ts
+++ b/src/fa.d.ts
@@ -12,19 +12,19 @@ declare class Fa extends SvelteComponent {
     icon: IconDefinition
 
     size?:
-      | "lg"
-      | "xs"
-      | "sm"
-      | "1x"
-      | "2x"
-      | "3x"
-      | "4x"
-      | "5x"
-      | "6x"
-      | "7x"
-      | "8x"
-      | "9x"
-      | "10x"
+      | 'lg'
+      | 'xs'
+      | 'sm'
+      | '1x'
+      | '2x'
+      | '3x'
+      | '4x'
+      | '5x'
+      | '6x'
+      | '7x'
+      | '8x'
+      | '9x'
+      | '10x'
       | (`${number}x` & {});
     color?: string;
 

--- a/test/fa.test-d.ts
+++ b/test/fa.test-d.ts
@@ -29,8 +29,13 @@ expectType<
   | '8x'
   | '9x'
   | '10x'
+  | `${number}x`
   | undefined
 >(fa.$$prop_def.size);
+expectAssignable<typeof fa.$$prop_def.size>("1.5x");
+//@ts-expect-error - this shouldn't be assignable
+expectAssignable<typeof fa.$$prop_def.size>("arbitrary-string-x");
+
 expectType<string | undefined>(fa.$$prop_def.color);
 
 expectType<boolean | undefined>(fa.$$prop_def.fw);


### PR DESCRIPTION
Fixes #153.
The `& {}` weirdness is to allow 1x through 10x to still appear in autocomplete.