### PR TITLE
Simplify template strings in markup

### DIFF
--- a/src/fa-layers-text.svelte
+++ b/src/fa-layers-text.svelte
@@ -19,16 +19,8 @@ export let translateY = 0;
 export let rotate = '';
 export let flip = false;
 
-let c;
 let s;
 
-$: c = joinCss(
-  [
-    clazz,
-    'svelte-fa-layers-text',
-  ],
-  ' ',
-);
 
 $: s = getStyles(
   joinCss([
@@ -44,7 +36,7 @@ $: s = getStyles(
 );
 </script>
 
-<span id={id} class={c}>
+<span id={id} class="svelte-fa-layers-text {clazz}">
   <span style={s}>
     <slot></slot>
   </span>

--- a/src/fa-layers.svelte
+++ b/src/fa-layers.svelte
@@ -1,7 +1,6 @@
 <script>
 import {
-  joinCss,
-  getStyles,
+  getStyles
 } from './utils';
 
 let clazz = '';
@@ -12,16 +11,7 @@ export let style = '';
 export let size = '';
 export let pull = '';
 
-let c;
 let s;
-
-$: c = joinCss(
-  [
-    clazz,
-    'svelte-fa-layers',
-  ],
-  ' ',
-);
 
 $: s = getStyles(style, size, pull, true);
 </script>
@@ -56,7 +46,7 @@ $: s = getStyles(style, size, pull, true);
 
 <span
   id={id}
-  class={c}
+  class="svelte-fa-layers {clazz}"
   style={s}
 >
   <slot></slot>

--- a/src/fa.svelte
+++ b/src/fa.svelte
@@ -1,8 +1,7 @@
 <script>
 import {
-  joinCss,
   getStyles,
-  getTransform,
+  getTransform
 } from './utils';
 
 let clazz = '';
@@ -35,21 +34,10 @@ export let secondaryOpacity = 0.4;
 export let swapOpacity = false;
 
 let i;
-let c;
 let s;
 let transform;
 
 $: i = (icon && icon.icon) || [0, 0, '', [], ''];
-
-$: c = joinCss(
-  [
-    clazz,
-    'svelte-fa',
-    spin && 'spin',
-    pulse && 'pulse',
-  ],
-  ' ',
-);
 
 $: s = getStyles(style, size, pull, fw);
 
@@ -78,36 +66,39 @@ $: transform = getTransform(scale, translateX, translateY, rotate, flip, 512);
 {#if i[4]}
   <svg
     {id}
-    class={c}
+    class="svelte-fa {clazz}"
+    class:pulse
+    class:spin
     style={s}
-    viewBox={`0 0 ${i[0]} ${i[1]}`}
+    viewBox="0 0 {i[0]} {i[1]}"
     aria-hidden="true"
     role="img"
     xmlns="http://www.w3.org/2000/svg"
   >
     <g
-      transform={`translate(${i[0] / 2} ${i[1] / 2})`}
-      transform-origin={`${i[0] / 4} 0`}
+      transform="translate({i[0] / 2} {i[1] / 2})"
+      transform-origin="{i[0] / 4} 0"
     >
       <g {transform}>
         {#if typeof i[4] == 'string'}
           <path
             d={i[4]}
             fill={color || primaryColor || 'currentColor'}
-            transform={`translate(${i[0] / -2} ${i[1] / -2})`}
+            transform="translate({i[0] / -2} {i[1] / -2})"
           />
         {:else}
+          <!-- Duotone icons -->
           <path
             d={i[4][0]}
             fill={secondaryColor || color || 'currentColor'}
             fill-opacity={swapOpacity != false ? primaryOpacity : secondaryOpacity}
-            transform={`translate(${i[0] / -2} ${i[1] / -2})`}
+            transform="translate({i[0] / -2} {i[1] / -2})"
           />
           <path
             d={i[4][1]}
             fill={primaryColor || color || 'currentColor'}
             fill-opacity={swapOpacity != false ? secondaryOpacity : primaryOpacity}
-            transform={`translate(${i[0] / -2} ${i[1] / -2})`}
+            transform="translate({i[0] / -2} {i[1] / -2})"
           />
         {/if}
       </g>


### PR DESCRIPTION
Svelte can interpolate values directly within the markup, no need to use template strings manually