### PR TITLE
prevent default empty id

### DIFF
--- a/src/fa.svelte
+++ b/src/fa.svelte
@@ -6,7 +6,7 @@ import {
 
 let clazz = '';
 export { clazz as class };
-export let id = '';
+export let id;
 export let style = '';
 
 export let icon;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/65339198/177992487-ac2228aa-4540-4d7b-9213-b0ce90df2e11.png)
Currently, when there is no id prop passed into an Fa component, it renders `id=''` in the SVG component. Changing 
`export let id = ''` to `export let id` seems to solve the problem