### PR TITLE
Fix invalid TypeScript configuration

### DIFF
--- a/src/basic.test.ts
+++ b/src/basic.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test, afterEach } from "vitest";
 // @ts-expect-error No typings available
 import { fasFlag, fasInfo } from "@cweili/fa-test-util";
 import { render, screen, cleanup } from "@testing-library/svelte";
-import Fa from "./lib";
+import Fa from "./lib/index.js";
 
 function mountFa(props: Partial<ComponentProps<Fa>>) {
   cleanup();

--- a/src/duotone.test.ts
+++ b/src/duotone.test.ts
@@ -3,7 +3,7 @@ import { expect, test, afterEach } from "vitest";
 // @ts-expect-error No typings available
 import { fasFlag, fadFlag, fadInfo } from "@cweili/fa-test-util";
 import { render, screen, cleanup } from "@testing-library/svelte";
-import Fa from "./lib";
+import Fa from "./lib/index.js";
 
 function mountFa(props: Partial<ComponentProps<Fa>>) {
   cleanup();

--- a/src/layers.test.ts
+++ b/src/layers.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test, afterEach } from "vitest";
 import { render, screen, cleanup, configure } from "@testing-library/svelte";
 import type { ComponentProps } from "svelte";
 
-import { FaLayers, FaLayersText } from "./lib";
+import { FaLayers, FaLayersText } from "./lib/index.js";
 
 configure({ testIdAttribute: "id" });
 afterEach(cleanup);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,8 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "noUnusedLocals": true,
-    "strict": true
-  },
-  "module": "nodenext",
-  "moduleResolution": "nodenext"
+    "strict": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
+  }
 }


### PR DESCRIPTION
The `module` and `moduleResolution` settings are compiler options, and thus must be part of the `compilerOptions` object to take effect. `NodeNext` and `Node16` are the only correct `module` options for code intended to run in Node.js 12+.

Per the documentation: [1]

> `node16` and `nodenext` are the only correct `module` options for all apps and libraries that are intended to run in Node.js v12 or later, whether they use ES modules or not.

Note: the option values are case-insensitive, and I used the casing matching the JSON schema and suggested by VS Code.

[1]: https://www.typescriptlang.org/docs/handbook/modules/reference.html#summary