### PR TITLE
Add svelte 5 as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "!dist/**/*.spec.*"
   ],
   "peerDependencies": {
-    "svelte": "^4.0.0"
+    "svelte": "^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "@cweili/fa-test-util": "^1.0.0",


### PR DESCRIPTION
This PR adds svelte 5 to the peer dependencies, in this way people can use the library with both svelte 4 and svelte 5. 
It's not a breaking change so it does not require a new major