### PR TITLE
Add title prop and tag

### DIFF
--- a/src/lib/fa.svelte
+++ b/src/lib/fa.svelte
@@ -9,6 +9,7 @@
   export let style: string | undefined = undefined;
 
   export let icon: IconDefinition;
+  export let title: string = undefined;
   export let size: IconSize | undefined = undefined;
   export let color: string | undefined = undefined;
 
@@ -60,6 +61,9 @@
     xmlns="http://www.w3.org/2000/svg"
   >
     <!-- eslint-enable -->
+    {#if title}
+      <title>{title}</title>
+    {/if}
     <g transform="translate({i[0] / 2} {i[1] / 2})" transform-origin="{i[0] / 4} 0">
       <g {transform}>
         {#if typeof i[4] == "string"}

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -197,3 +197,15 @@ test("spin", async () => {
   expect(classList.contains("spin")).toBeTruthy();
   expect(classList.contains("pulse")).toBeTruthy();
 });
+
+test("title", async () => {
+  const title = "Svelte FA’s test icon";
+  mountFa({
+    title,
+  });
+
+  const tag = await screen.findByText(title);
+  expect(tag).to.exist;
+  // For backward compatibility with SVG 1.1, according to MDN
+  expect(getFa().querySelector(":first-child")).toBe(tag);
+});


### PR DESCRIPTION
This PR adds a new optional `title` prop. When this prop is set, includes a [`title`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/title) tag as first child of the `svg` tag.

Closes https://github.com/Cweili/svelte-fa/issues/328.