### PR TITLE
Deactivate aria-hidden if title is present

### DIFF
--- a/src/lib/fa.svelte
+++ b/src/lib/fa.svelte
@@ -58,7 +58,7 @@
     bind:this={svgElement}
     {style}
     viewBox="0 0 {i[0]} {i[1]}"
-    aria-hidden="true"
+    aria-hidden={title === undefined}
     role="img"
     xmlns="http://www.w3.org/2000/svg"
   >

--- a/src/routes/showcase.svelte
+++ b/src/routes/showcase.svelte
@@ -20,6 +20,7 @@
   let pull = ["None", "Left", "Right"];
   let flip = ["None", "Horizontal", "Vertical", "Both"];
   let icons = [faFlag, faHome, faCog, faSeedling];
+  let iconsTitles = ["flag", "home", "cog", "seedling"];
 
   function setPull(value: string) {
     let pull: "left" | "right" | undefined = undefined;
@@ -160,7 +161,7 @@
       </form>
     </div>
     <div class="col-md row">
-      {#each icons as icon}
+      {#each icons as icon, i}
         <div class="col text-center hue">
           <Fa
             {icon}
@@ -168,6 +169,7 @@
             pull={model.pull}
             rotate={model.rotate}
             size={`${model.size}x`}
+            title={iconsTitles[i]}
           />
         </div>
       {/each}

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -32,6 +32,7 @@ test("basic", async () => {
   });
 
   expect(getFa().getAttribute("id")).toBe("a");
+  expect(getFa().getAttribute("aria-hidden")).toBe("true");
   expect(getFa().getAttribute("class")).toContain("class-a");
   expect(getFa().getAttribute("style")).toContain("color:red");
   expect(getFa().querySelector("path")?.getAttribute("d")).toBe(fasFlag.icon[4]);
@@ -203,6 +204,7 @@ test("title", async () => {
     title,
   });
 
+  expect(getFa().getAttribute("aria-hidden")).toBe("false");
   const tag = await screen.findByText(title);
   // eslint-disable-next-line @typescript-eslint/no-unused-expressions
   expect(tag).to.exist;


### PR DESCRIPTION
Hello,

I’m feeling like an idiot but I only just saw that I forgot a change in my previous PR (#336): the `aria-hidden="true"` is hiding the whole SVG, including the title so this new PR makes `aria-hidden` now depend on the absence of `title`.
I also added titles to the four icons of the showcase to actually test in situ rather than with modifying the dist in my node_modules.

Apologies for the fail last time ^^'